### PR TITLE
In-tag client-error logging solution for safeframes and non-safeframes.

### DIFF
--- a/src/library/required/extension/omg-client-logger-preloader.js
+++ b/src/library/required/extension/omg-client-logger-preloader.js
@@ -1,0 +1,110 @@
+(function (omg) {
+    omg = omg || {};
+
+    var CLIENT_ERROR_LABEL = 'omg.utag.client-error';
+    var POST_MESSAGE_COMMAND = 'client-log-error';
+    var SAFEFRAMES = 'safeframes';
+
+    var SafeFramesClientLogger = function () {};
+    SafeFramesClientLogger.prototype = {
+        logError: function (error, additionalData) {
+            if ('undefined' === typeof top || 'undefined' === top.postMessage) {
+                return;
+            }
+            additionalData = additionalData || [];
+            additionalData.push(SAFEFRAMES + '=true');
+            var errorMessage = this.createSafeframesMessage(error, additionalData);
+            var sourceUrl = '';
+            if ('undefined' !== typeof utag_data && 'undefined' !== typeof utag_data.parenturl) {
+                sourceUrl = utag_data.parenturl;
+            }
+            top.postMessage('cmd=' + POST_MESSAGE_COMMAND + '&value=' + JSON.stringify(errorMessage), sourceUrl);
+        },
+        /**
+         * @param error Javascript error object
+         * @param additionalData
+         * @returns {{message: string, fileName: string, stack: Array}}
+         */
+        createSafeframesMessage: function(error, additionalData) {
+            var msg = {
+                label: CLIENT_ERROR_LABEL,
+                message: "",
+                fileName: "",
+                stack: [],
+                additionalData: additionalData
+            };
+            msg.message = error.message;
+            msg.fileName = getSource(error);
+            msg.stack = parseStack(error);
+            return msg;
+        }
+    };
+
+    var DctkClientLogger = function () {};
+    DctkClientLogger.prototype = {
+        logError: function (error, additionalData) {
+            additionalData = additionalData || [];
+            additionalData.push(SAFEFRAMES + '=false');
+            error.fileName = getSource(error);
+            error.stack = parseStack(error).join(", ");
+            dctk.logging.logError(CLIENT_ERROR_LABEL, error, additionalData);
+        }
+    };
+
+    var NoOpClientLogger = function () {};
+    NoOpClientLogger.prototype = {
+        logError: function (error, additionalData) {}
+    };
+
+    /**
+     * @param error Javascript error Object
+     * @returns The page source or the entire stack string.
+     */
+    function getSource(error) {
+        if ('string' === typeof error.stack) {
+            var stackArr = error.stack.split(/[\r\n]+/g);
+            if (stackArr.length > 1) {
+                return parseSource(stackArr[1]);
+            }
+        }
+        return error.stack;
+    }
+
+    function parseSource(rawLine) {
+        var line = rawLine.replace(/at/gi, '').trim();
+        if (line.indexOf('?') !== -1) {
+            return line.split('?')[0];
+        }
+        return line;
+    }
+
+    function parseStack(error) {
+        var stack = [];
+        if ('string' === typeof error.stack) {
+            var stackArr = error.stack.split(/[\r\n]+/g);
+            for (var i = 0; i < stackArr.length; i++) {
+                stack.push(stackArr[i].trim());
+            }
+        }
+        return stack;
+    }
+
+    function createClientLogger() {
+        if (isDctkErrorLoggingAvailable()) {
+            return new DctkClientLogger();
+        } else if (isSafeFramesAvailable()) {
+            return new SafeFramesClientLogger();
+        }
+        return new NoOpClientLogger();
+    }
+
+    function isDctkErrorLoggingAvailable() {
+        return 'undefined' !== typeof dctk && 'undefined' !== typeof dctk.logging && 'undefined' !== typeof dctk.logging.logError;
+    }
+
+    function isSafeFramesAvailable() {
+        return 'sf_body' === document.body.id;
+    }
+
+    omg.clientLogger = createClientLogger();
+})(omg);


### PR DESCRIPTION
### Example Code Error and the client-error log rendered

![image](https://cloud.githubusercontent.com/assets/6675274/22485814/ec41ef38-e7bb-11e6-9524-2a8db50c1c04.png)

#### Non-Safeframes:
```
omg.utag.client-error
onErrorMsg="idXXX is not defined"
onErrorUrl="https://tags.tiqcdn.com/utag/expedia/main/dev/utag.427.js"
onErrorLine="NA"
onErrorChar="NA"
stack="ReferenceError: idXXX is not defined, at https://tags.tiqcdn.com/utag/expedia/main/dev/utag.427.js?utv=ut4.39.201603150251:123:31, at https://tags.tiqcdn.com/utag/expedia/main/dev/utag.427.js?utv=ut4."
safeframes=false
```

#### Safeframes:
```
client-logging-bundle-min.js:1 omg.utag.client-error
onErrorMsg="idXXX is not defined"
onErrorUrl="https://tags.tiqcdn.com/utag/expedia/main/dev/utag.427.js"
onErrorLine="NA"
onErrorChar="NA"
stack="ReferenceError: idXXX is not defined, at https://tags.tiqcdn.com/utag/expedia/main/dev/utag.427.js?utv=ut4.39.201603150251:123:31, at https://tags.tiqcdn.com/utag/expedia/main/dev/utag.427.js?utv=ut4."
safeframes=true
```

#### Splunk Example (Safeframes):
![image](https://cloud.githubusercontent.com/assets/6675274/22485795/d75f4d2c-e7bb-11e6-8c72-3563624dc5b5.png)
