### PR TITLE
Add brand to omgpixel* payload

### DIFF
--- a/src/library/required/extension/omg-pixel-collector-web-preloader.js
+++ b/src/library/required/extension/omg-pixel-collector-web-preloader.js
@@ -162,12 +162,15 @@
     }
 
     function createLogPixelPayload(tagInfo) {
-        var siteId, siteName;
+        var siteId, siteName, siteBrand;
         if (b.context && b.context.site) {
             siteId = b.context.site.siteId || -1;
         }
         if (b.context && b.context.site) {
             siteName = b.context.site.siteName;
+        }
+        if (b.SiteBrand) {
+            siteBrand = b.SiteBrand;
         }
 
         var pageName, lob, xlob, funnelLocation;
@@ -196,7 +199,8 @@
             },
             "site": {
                 "id": siteId,
-                "name": siteName
+                "name": siteName,
+                "brand": siteBrand
             },
             "page": {
                 "name": pageName,


### PR DESCRIPTION
Manually tested and fired in trunk with following results for omgpixel. The omgmarketingpixel should render similar result on site element.

Console:
```javascript
omg.pixel.fireTagPixel({id:123, name:'tonytest'})
```

Output:
```javascript
{
  "source": "tealium",
  "utcTimestamp": 1487104934572,
  "tealium": {
    "profile": "main",
    "env": "dev"
  },
  "site": {
    "id": 1,
    "name": "wwwexpediacom.trunk.sb.karmalab.net",
    "brand": "Expedia"
  },
  "page": {
    "name": "Homepage",
    "lob": "storefront",
    "xlob": "UNCLASSIFIED",
    "funnelLocation": "ENTRY"
  },
  "tag": {
    "id": 123,
    "name": "tonytest",
    "dataMapping": ""
  }
}
```
