### PR TITLE
adding page name function for page.Flight.Checkout.Payment

### DIFF
--- a/src/library/simplified/extension/page-name-javascript-functions.js
+++ b/src/library/simplified/extension/page-name-javascript-functions.js
@@ -113,7 +113,7 @@ window.utag.isFTP = function(){
 }
 
 window.utag.isFPymt = function(){
-    if(pageName.indexOf("FLT_CKO_PMT") > -1 || pageName.indexOf("page.Flight.Checkout.Info") > -1){
+    if(pageName.indexOf("FLT_CKO_PMT") > -1 || pageName.indexOf("page.Flight.Checkout.Info") || pageName.indexOf("page.Flight.Checkout.Payment") > -1){
         b["isFlightPayment"] = true;
         b["pageType"] = "Payment";
         return true ;


### PR DESCRIPTION
The flight checkout page name is "page.Flight.Checkout.Payment" instead of  "page.Flight.Checkout.Info" when the abacus 12128 is enabled. Hence added this.

![image](https://cloud.githubusercontent.com/assets/21168840/26341464/94fa73c8-3fb1-11e7-924f-024591f28adc.png)

with 12128
![image](https://cloud.githubusercontent.com/assets/21168840/26341478/a93a6ea6-3fb1-11e7-8b7b-6541e5fba275.png)

