### PR TITLE
Segmentation value in Google Analytics tag

### DIFF
--- a/google_analytics_segments
+++ b/google_analytics_segments
@@ -1,0 +1,5 @@
+var gaCustAud = "NOSEG";
+if(utag_data['context.user.guid'] != undefined){
+	var gaCustAud = parseInt(utag_data['context.user.guid'].split("-")[0],16) % 101;	  
+}
+ b.ga_user_segment_id = gaCustAud;


### PR DESCRIPTION
We need to send a parameter to Google that sends a number between 0 (inclusive) and 100 (exclusive) for every GUID. This code allows us to do that so that Google on their side can use that value to segment users together.